### PR TITLE
Remove extra comma from function parameter list.

### DIFF
--- a/src/website/index.html
+++ b/src/website/index.html
@@ -93,7 +93,7 @@
                 cognito: {},
                 lex: {},
               },
-              config,
+              config
             );
 
             mergedConfig.cognito.poolId = poolId;


### PR DESCRIPTION
This extra comma prevented index.html from rendering. I viewed with IE11 and Chrome 53 and this syntax error prevented the page from rendering. Removing it fixed the problem locally so I thought a pull request should be made to fix it permanently for others.